### PR TITLE
Autoload models and allow registering associations from within models.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,7 @@ import responseTime from 'response-time';
 import configs from './modules/config';
 import loggers from './modules/logging';
 import bindAuth from './modules/auth';
-import { loadModels } from './modules/database';
+// import { loadModels } from './modules/database';
 
 import flavor from './routes/flavor';
 // import recipe from './routes/recipe';
@@ -19,7 +19,7 @@ const log = loggers('app');
 export const app = express();
 
 export const start = async () => {
-  await loadModels();
+  //  await loadModels();
 
   // common middleware
   app.use(responseTime());

--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,6 @@ import responseTime from 'response-time';
 import configs from './modules/config';
 import loggers from './modules/logging';
 import bindAuth from './modules/auth';
-// import { loadModels } from './modules/database';
 
 import flavor from './routes/flavor';
 // import recipe from './routes/recipe';
@@ -19,8 +18,6 @@ const log = loggers('app');
 export const app = express();
 
 export const start = async () => {
-  //  await loadModels();
-
   // common middleware
   app.use(responseTime());
   app.use(bodyParser.json());

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+
+function Models(sequelize) {
+  const basename = path.basename(__filename);
+
+  const db = {};
+
+  fs.readdirSync(__dirname)
+    .filter(file => {
+      return (
+        file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
+      );
+    })
+    .forEach(file => {
+      const model = sequelize.import(path.join(__dirname, file));
+
+      db[model.name] = model;
+    });
+
+  Object.keys(db).forEach(modelName => {
+    if (db[modelName].associate) {
+      db[modelName].associate(db);
+    }
+  });
+
+  db.sequelize = sequelize;
+
+  return db;
+}
+
+export default Models;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,37 +1,39 @@
-import { Model, DataTypes } from 'sequelize';
-
-module.exports = class User extends Model {
-  static init(sequelize) {
-    return super.init(
-      {
-        id: {
-          type: DataTypes.BIGINT,
-          allowNull: false,
-          primaryKey: true
-        },
-        emailAddress: {
-          type: DataTypes.STRING,
-          allowNull: false
-        },
-        password: {
-          type: DataTypes.STRING,
-          allowNull: false
-        },
-        created: {
-          type: DataTypes.DATE,
-          allowNull: false
-        },
-        activationCode: {
-          type: DataTypes.STRING
-        }
+module.exports = (sequelize, DataTypes) => {
+  const User = sequelize.define(
+    'User',
+    {
+      id: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true
       },
-      {
-        sequelize,
-        underscored: true,
-        tableName: 'user',
-        createdAt: 'created',
-        updatedAt: false
+      emailAddress: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      password: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false
+      },
+      activationCode: {
+        type: DataTypes.STRING
       }
-    );
-  }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'user',
+      createdAt: 'created',
+      updatedAt: false
+    }
+  );
+
+  /* User.associate = function(models) {
+    // associations can be defined here
+  };*/
+  return User;
 };

--- a/src/models/userToken.js
+++ b/src/models/userToken.js
@@ -1,38 +1,36 @@
-import { Model, DataTypes } from 'sequelize';
-
-module.exports = class UserToken extends Model {
-  static init(sequelize) {
-    return super.init(
-      {
-        token: {
-          type: DataTypes.STRING,
-          allowNull: false,
-          primaryKey: true
-        },
-        userId: {
-          type: DataTypes.INTEGER,
-          allowNull: false
-        },
-        created: {
-          type: DataTypes.DATE,
-          allowNull: false
-        },
-        expires: {
-          type: DataTypes.DATE,
-          allowNull: false
-        }
+module.exports = (sequelize, DataTypes) => {
+  const UserToken = sequelize.define(
+    'UserToken',
+    {
+      token: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        primaryKey: true
       },
-      {
-        sequelize,
-        underscored: true,
-        tableName: 'user_token',
-        createdAt: 'created',
-        updatedAt: false
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false
+      },
+      expires: {
+        type: DataTypes.DATE,
+        allowNull: false
       }
-    );
-  }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'user_token',
+      createdAt: 'created',
+      updatedAt: false
+    }
+  );
 
-  static associate(models) {
+  UserToken.associate = function(models) {
     this.belongsTo(models.User, { foreignKey: 'userId' });
-  }
+  };
+  return UserToken;
 };

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -11,7 +11,6 @@ passport.use(
     const { UserToken, User } = models;
 
     try {
-      UserToken.belongsTo(User, { foreignKey: 'userId' });
       const result = await UserToken.findAll({
         where: {
           token

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -1,19 +1,19 @@
-import globby from 'globby';
-import { join } from 'path';
+// import globby from 'globby';
+// import { join } from 'path';
 import Sequelize from 'sequelize';
-
 import configs from './config';
-import loggers from './logging';
+import models from '../models';
+// import loggers from './logging';
 
-const log = loggers('database');
+// const log = loggers('database');
 const { host, port, password, username, database } = configs.database;
 
-export const sequelize = new Sequelize(database, username, password, {
+const sequelize = new Sequelize(database, username, password, {
   host,
   port,
   dialect: 'postgres'
 });
-
+/*
 export const loadModels = async () => {
   try {
     const modelPaths = await globby(join(__dirname, '..', 'models', '*.js'));
@@ -39,5 +39,10 @@ export const loadModels = async () => {
     log.error(error.stack);
   }
 };
+*/
 
-export default sequelize.models;
+var db = models(sequelize);
+
+db.Sequelize = Sequelize;
+
+export default db;

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -1,11 +1,7 @@
-// import globby from 'globby';
-// import { join } from 'path';
 import Sequelize from 'sequelize';
 import configs from './config';
 import models from '../models';
-// import loggers from './logging';
 
-// const log = loggers('database');
 const { host, port, password, username, database } = configs.database;
 
 const sequelize = new Sequelize(database, username, password, {
@@ -13,33 +9,6 @@ const sequelize = new Sequelize(database, username, password, {
   port,
   dialect: 'postgres'
 });
-/*
-export const loadModels = async () => {
-  try {
-    const modelPaths = await globby(join(__dirname, '..', 'models', '*.js'));
-
-    const models = modelPaths.reduce((result, modelPath) => {
-      const Model = require(modelPath);
-
-      const model = Model.init(sequelize);
-
-      return {
-        ...result,
-        [Model.name]: model
-      };
-    }, {});
-
-    for (const model of Object.values(models)) {
-      if (typeof model.associate === 'function') {
-        model.associate(models);
-      }
-    }
-  } catch (error) {
-    log.error(error.message);
-    log.error(error.stack);
-  }
-};
-*/
 
 var db = models(sequelize);
 

--- a/src/routes/flavor.js
+++ b/src/routes/flavor.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { check, validationResult } from 'express-validator/check';
 
-import { sequelize } from '../modules/database';
+import database from '../modules/database';
 import loggers from '../modules/logging';
 
 const router = Router();
@@ -23,7 +23,7 @@ router.get(
 
     log.info(`request for ${req.params.id}`);
     try {
-      const result = await sequelize.query(
+      const result = await database.sequelize.query(
         `select
           v.code vendor_code,
           v.name vendor_name,
@@ -42,7 +42,7 @@ router.get(
       }
 
       res.type('application/json');
-      res.writeHead(200).end(JSON.stringify(result[0].shift()));
+      res.json(result.shift().shift());
     } catch (error) {
       log.error(error.message);
       res.writeHead(500).end(error.message);


### PR DESCRIPTION
Stole the method used by the sequelize-cli tool, which uses a loader within the models folder. 
Adapted it to be used by the database module.
Removed the belongsTo() method from auth.js
I can remove the comments before the merge if desired